### PR TITLE
Feat/Implement get_cmd_path function

### DIFF
--- a/get_cmd_path.c
+++ b/get_cmd_path.c
@@ -1,0 +1,49 @@
+#include "main.h"
+
+/**
+ * get_cmd_path - find the cmd in the PATH
+ * @arg: char - first arg read by getline
+ * Return: return the full_path if found - else return NULL
+ */
+
+char *get_cmd_path(char *arg)
+{
+
+	char *env;
+	char *env_copy;
+	char *dir;
+	char *full_path;
+
+	env = getenv("PATH");
+	env_copy = strdup(env);
+	dir = strtok(path_copy, ":");
+
+	while (dir != NULL)
+	{
+
+		full_path = malloc(strlen(dir) + strlen(arg) + 2);
+		if (full_path == NULL)
+		{
+			free(env_copy);
+			return (NULL);
+		}
+		if (full_path != NULL)
+		{
+			strcpy(full_path, dir);
+			strcat(full_path, "/");
+			strcat(full_path, arg);
+		}
+		if (stat(full_path, &st) == 0)
+		{
+			free(env_copy);
+			return (full_path);
+		}
+		else
+			{
+				free(full_path);
+				dir = strtok(NULL, ":");
+			}
+	}
+	free(env_copy);
+	return (NULL);
+}

--- a/get_cmd_path.c
+++ b/get_cmd_path.c
@@ -13,10 +13,12 @@ char *get_cmd_path(char *arg)
 	char *env_copy;
 	char *dir;
 	char *full_path;
+	struct stat st;
+
 
 	env = getenv("PATH");
 	env_copy = strdup(env);
-	dir = strtok(path_copy, ":");
+	dir = strtok(env_copy, ":");
 
 	while (dir != NULL)
 	{

--- a/main.c
+++ b/main.c
@@ -11,8 +11,7 @@ int main(void)
 	size_t n = 0;
 	ssize_t user_input;
 	int checker;
-
-	char *line = NULL;
+	char *path, *line = NULL;
 
 	while (1)
 	{
@@ -27,15 +26,22 @@ int main(void)
 		if (args == NULL || args[0] == NULL)
 			continue; /*if the parsing fails or if input is empty*/
 
-		checker = check_if_command_exists(args[0]);
-		if (checker == 0)
+			checker = check_if_command_exists(args[0]);
+		if (checker == 1)
 		{
-			execute_cmd_line(args);
+			path = get_cmd_path(args[0]);
+
+			if (path != NULL)
+			{
+				args[0] = path;
+				execute_cmd_line(args);
+			}
+			else
+				printf("Command doesn't exist");
 		}
 		else
-		{
-			printf("Command doesn't exist\n");
-		}
+			execute_cmd_line(args);
+
 		free(args);
 	}
 	free(line);

--- a/main.c
+++ b/main.c
@@ -26,7 +26,7 @@ int main(void)
 		if (args == NULL || args[0] == NULL)
 			continue; /*if the parsing fails or if input is empty*/
 
-			checker = check_if_command_exists(args[0]);
+		checker = check_if_command_exists(args[0]);
 		if (checker == 1)
 		{
 			path = get_cmd_path(args[0]);
@@ -37,7 +37,7 @@ int main(void)
 				execute_cmd_line(args);
 			}
 			else
-				printf("Command doesn't exist");
+				printf("Command doesn't exist\n");
 		}
 		else
 			execute_cmd_line(args);

--- a/main.h
+++ b/main.h
@@ -18,5 +18,6 @@ extern char **environ;
 char **parsing_user_input(char *line);
 int check_if_command_exists(char *arg);
 int execute_cmd_line(char **args);
+char *get_cmd_path(char *arg);
 
 #endif


### PR DESCRIPTION
# Get_cmd_path function

In order to execute the command, if the input is not an absolute path, we check in the environnement variable if it exists.

For example, here is the PATH of our device :
`PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/usr/lib/wsl/lib:.........`.

The function `get_cmd_path` parses a copy of this PATH with the function `strtok()`, using `:` as a delimiter.
```c
dir = strtok(env_copy, ":");
```

After that, we add in an allocated variable `full_path`  one token `dir` (representing one directory of our path) `\` and our command to test : 
```c
		if (full_path != NULL)
		{
			strcpy(full_path, dir);
			strcat(full_path, "/");
			strcat(full_path, arg);
		}
```

In a loop, we check every full path  using the function `stat()`.

```c
if (stat(full_path, &st) == 0)
		{
			free(env_copy);
			return (full_path);
		}
```

If the command exists in the directory, we return it to the main function.
If the command doesn't exists, we return NULL.


We bring this function into the main one : 

-we first check if the arg is a full path of a command. If it is we send it to the exec function.
-otherwise, we use the get_cmd_path function.
-if the function return is NULL, we print "Command doesn't exist"

```c
checker = check_if_command_exists(args[0]);
		if (checker == 1)
		{
			path = get_cmd_path(args[0]);

			if (path != NULL)
			{
				args[0] = path;
				execute_cmd_line(args);
			}
			else
				printf("Command doesn't exist\n");
		}
```