### PR TITLE
Feat/implement exit built in

### DIFF
--- a/builtins/check_builtins.c
+++ b/builtins/check_builtins.c
@@ -1,0 +1,29 @@
+#include "main.h"
+
+/**
+ * check_builtins - checks if cmd passed by the user is a builtins functions
+ * and roots to the associated function
+ * @args: pointer to array of string - args passed to our shell
+ * Return: int - (0) if success through the pointed function -
+ * (-1) if don't match
+ */
+int check_builtins(char **args)
+{
+	int i;
+
+	i = 0;
+
+	builtin_t array_of_builtins[] = {
+		{"exit", handle_exit},
+		{NULL, NULL}
+	};
+
+	while (array_of_builtins[i].name != NULL && array_of_builtins[i].f != NULL)
+	{
+		if (strcmp(array_of_builtins[i].name, args[0]) == 0)
+			return (array_of_builtins[i].f(args));
+		i++;
+	}
+
+	return (-1);
+}

--- a/builtins/check_builtins.c
+++ b/builtins/check_builtins.c
@@ -11,13 +11,13 @@ int check_builtins(char **args)
 {
 	int i;
 
-	i = 0;
-
+	
 	builtin_t array_of_builtins[] = {
 		{"exit", handle_exit},
 		{NULL, NULL}
 	};
-
+	
+	i = 0;
 	while (array_of_builtins[i].name != NULL && array_of_builtins[i].f != NULL)
 	{
 		if (strcmp(array_of_builtins[i].name, args[0]) == 0)

--- a/builtins/check_builtins.c
+++ b/builtins/check_builtins.c
@@ -1,4 +1,4 @@
-#include "main.h"
+#include "../main.h"
 
 /**
  * check_builtins - checks if cmd passed by the user is a builtins functions

--- a/builtins/handle_exit.c
+++ b/builtins/handle_exit.c
@@ -1,4 +1,4 @@
-#include "main.h"
+#include "../main.h"
 
 /**
  * handle_exit - exit function to quit prog
@@ -10,7 +10,7 @@ int handle_exit(char **args)
 {
 	int exit_code;
 
-	if (!args[1])	
+	if (!args[1])
 		exit(0);
 
 	exit_code = _atoi(args[1]);

--- a/builtins/handle_exit.c
+++ b/builtins/handle_exit.c
@@ -1,0 +1,21 @@
+#include "main.h"
+
+/**
+ * handle_exit - exit function to quit prog
+ * @args: pointer of array of string - use to handle args for exit cmd
+ * Return: int
+ */
+
+int handle_exit(char **args)
+{
+	int exit_code;
+
+	if (!args[1])	
+		exit(0);
+
+	exit_code = _atoi(args[1]);
+
+	exit(exit_code);
+
+	return (0);
+}

--- a/helpers/_atoi.c
+++ b/helpers/_atoi.c
@@ -1,0 +1,31 @@
+/**
+* _atoi - convert a string to an integer
+* @s: pointer to string - string to convert
+* Return: integer
+*/
+
+int _atoi(char *s)
+{
+	int i = 0;
+	int sign = 1;
+	unsigned int dest = 0;
+	int started = 0;
+
+	while (s[i] != '\0')
+	{
+
+		if ((s[i] == '-') && started == 0)
+			sign *= -1;
+
+		if (s[i] >= '0' && s[i] <= '9')
+		{
+			started = 1;
+			dest = dest * 10 + (s[i] - '0');
+		} else if (started)
+		{
+			break;
+		}
+		i++;
+	}
+	return (dest * sign);
+}

--- a/main.c
+++ b/main.c
@@ -25,17 +25,23 @@ int main(void)
 		args = parsing_user_input(line);
 
 		if (args == NULL || args[0] == NULL)
+		{
+			free(args);
 			continue; /*if the parsing fails or if input is empty*/
+		}
 
+		if (check_builtins(args) != -1)
+		{
+			free(args);
+			continue;
+		}
 		checker = check_if_command_exists(args[0]);
 		if (checker == 0)
 		{
 			execute_cmd_line(args);
 		}
 		else
-		{
 			printf("Command doesn't exist\n");
-		}
 		free(args);
 	}
 	free(line);

--- a/main.h
+++ b/main.h
@@ -26,6 +26,7 @@ char **parsing_user_input(char *line);
 int check_if_command_exists(char *arg);
 int execute_cmd_line(char **args);
 int handle_exit(char **args);
+int check_builtins(char **args);
 int _atoi(char *s);
 
 #endif

--- a/main.h
+++ b/main.h
@@ -12,11 +12,20 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 
+/* Structures */
+typedef struct builtin_s
+{
+	char *name;
+	int (*f)(char **args);
+} builtin_t;
+
 extern char **environ;
 
 /*prototypes*/
 char **parsing_user_input(char *line);
 int check_if_command_exists(char *arg);
 int execute_cmd_line(char **args);
+int handle_exit(char **args);
+int _atoi(char *s);
 
 #endif


### PR DESCRIPTION
In order to more closely replicate the behavior of the original shell I implement the feature to handle exit keyword.

You can see in this example I used the 'exit' and the return value is (0):
```bash
holbertonschool-simple_shell feat/implement-exit-built-in ❯ ./a.out 
<3 exit

holbertonschool-simple_shell feat/implement-exit-built-in ❯ echo $?
0
```

I put it into differnts folders `builtins` for the handle_exit function and the checker that roots to the good function.  
And the `helpers` dir to put our custom _atoi() because it's not in the allowed functions list.

The condition bloc into the main.c is just before the cmd checker :
```c
		if (check_builtins(args) != -1)
		{
			free(args);
			continue;
		}
		checker = check_if_command_exists(args[0]);
```

I almost make a little fix and free(args) in this block avoid memory:

```c
		if (args == NULL || args[0] == NULL)
		{
			free(args);
			continue; /*if the parsing fails or if input is empty*/
		}
```