### PR TITLE
Impelment `env` buitlin function

### DIFF
--- a/check_builtins.c
+++ b/check_builtins.c
@@ -11,13 +11,13 @@ int check_builtins(char **args)
 {
 	int i;
 
-	
+
 	builtin_t array_of_builtins[] = {
 		{"exit", handle_exit},
 		{"env", handle_env},
 		{NULL, NULL}
 	};
-	
+
 	i = 0;
 	while (array_of_builtins[i].name != NULL && array_of_builtins[i].f != NULL)
 	{

--- a/check_builtins.c
+++ b/check_builtins.c
@@ -14,6 +14,7 @@ int check_builtins(char **args)
 	
 	builtin_t array_of_builtins[] = {
 		{"exit", handle_exit},
+		{"env", handle_env},
 		{NULL, NULL}
 	};
 	

--- a/handle_env.c
+++ b/handle_env.c
@@ -3,7 +3,7 @@
 /**
  * handle_env - display all environment variables when `env` is called
  * @args: pointer of array of string - use to handle args for exit cmd
- * Return: int - 0
+ * Return: int - (0) on success
  */
 
 int handle_env(char **args)

--- a/handle_env.c
+++ b/handle_env.c
@@ -1,0 +1,21 @@
+#include "main.h"
+
+/**
+ * handle_env - display all environment variables when `env` is called
+ * @args: pointer of array of string - use to handle args for exit cmd
+ * Return: int - 0
+ */
+
+int handle_env(char **args)
+{
+	int i;
+
+	i = 0;
+	(void)args;
+	while (environ[i] != NULL)
+	{
+		printf("%s\n", environ[i]);
+		i++;
+	}
+	return (0);
+}

--- a/main.h
+++ b/main.h
@@ -13,6 +13,12 @@
 #include <sys/wait.h>
 
 /* Structures */
+/**
+ * struct builtin_s - Built-ins structure
+ *
+ * @name: name of the command built-in
+ * @f: function pointer handling the command
+ */ 
 typedef struct builtin_s
 {
 	char *name;

--- a/main.h
+++ b/main.h
@@ -26,6 +26,7 @@ char **parsing_user_input(char *line);
 int check_if_command_exists(char *arg);
 int execute_cmd_line(char **args);
 int handle_exit(char **args);
+int handle_env(char **args);
 int check_builtins(char **args);
 int _atoi(char *s);
 char *get_cmd_path(char *arg);


### PR DESCRIPTION
In order to mimic the behavior of the real shell when the user enters the `env` command—which prints the environment variables—we have implemented a function that does just that.