### PR TITLE
Feat/getenv function

### DIFF
--- a/_getenv.c
+++ b/_getenv.c
@@ -1,0 +1,29 @@
+#include "main.h"
+
+/**
+ * _getenv - gets an environment variable
+ * @target: the name of the variable to find
+ * Return: string - pointer to the value, or NULL
+ */
+
+char *_getenv(const char *target)
+{
+	int i, length;
+
+
+	length = 0;
+	while (target[length]) /*measure the length of target*/
+		length++;
+
+
+	for (i = 0; environ[i]; i++)
+	{
+/* compare target string with environment variable and check for '=' */
+		if (strncmp(environ[i], target, length) == 0 && environ[i][length] == '=')
+		{   /*returns a pointer to the char after '=' */
+			return (&environ[i][length + 1]);
+		}
+	}
+
+	return (NULL);
+}

--- a/get_cmd_path.c
+++ b/get_cmd_path.c
@@ -16,7 +16,7 @@ char *get_cmd_path(char *arg)
 	struct stat st;
 
 
-	env = getenv("PATH");
+	env = _getenv("PATH");
 	env_copy = strdup(env);
 	dir = strtok(env_copy, ":");
 

--- a/main.h
+++ b/main.h
@@ -37,5 +37,6 @@ int check_builtins(char **args);
 int _atoi(char *s);
 char *get_cmd_path(char *arg);
 void process_cmd(char **args);
+char *_getenv(const char *target);
 
 #endif


### PR DESCRIPTION
# _getenv function

Feature : in order to respect the requirements, we couldn't use the getenv function and we had to create our own.

How : 

-measure the length of our target.
-check every lines of `environ` 
-with `strncmp`, we compare our target with the *length first char of environ[i].

ex : 
*target = "PATH"
length = 4

-next, compares the first 4 char of environ with our target "PATH".
-if `strncmp` returns 0, the strings are the same.
-then, we check if the next char is '='
-if it is, we return the adress of the element after the `=`

```c
if (strncmp(environ[i], target, length) == 0 && environ[i][length] == '=')
		{   /*returns a pointer to the char after '=' */
			return (&environ[i][length + 1]);
		}
	}
```
