### PR TITLE
fix: Display the prompt only in interactive mode. Use of isatty

### DIFF
--- a/main.c
+++ b/main.c
@@ -13,7 +13,9 @@ int main(void)
 
 	while (1)
 	{
-		printf("<3 ");
+		if (isatty(STDIN_FILENO))
+			printf("<3 ");
+
 		user_input = getline(&line, &n, stdin);
 		if (user_input == -1)
 			break;


### PR DESCRIPTION
Currently, the shell always operates in interactive mode, printing the prompt `<3` even when receiving input from a pipe or file redirection. This behavior pollutes the output when the shell is used in non-interactive scenarios.

Here is what we should have : 
```c 
julien@ubuntu:~/shell$ ./shell 
#cisfun$ /bin/ls
barbie_j       env-main.c  exec.c  fork.c  pid.c  ppid.c    prompt   prompt.c  shell.c    stat.c         wait
env-environ.c  exec       fork    mypid   ppid   printenv  promptc  shell     stat test_scripting.sh  wait.c
#cisfun$ ^C
julien@ubuntu:~/shell$ echo "/bin/ls" | ./shell
barbie_j       env-main.c  exec.c  fork.c  pid.c  ppid.c    prompt   prompt.c  shell.c    stat.c         wait
env-environ.c  exec       fork    mypid   ppid   printenv  promptc  shell     stat test_scripting.sh  wait.c
julien@ubuntu:~/shell$ 
```

We need to implement a check to detect whether the shell is running in an interactive terminal or being fed via a pipe/file.

## Proposed Solution
Use isatty(STDIN_FILENO) (from <unistd.h>) within the main loop.

If isatty(STDIN_FILENO) returns 1 (true), we are in an interactive terminal and should print the prompt.

If it returns 0 (false), we are in a non-interactive mode and should skip the prompt printing.