### PR TITLE
fix: Handle errors correctly.

### DIFF
--- a/check_builtins.c
+++ b/check_builtins.c
@@ -14,7 +14,6 @@ int check_builtins(char **args, char *prog, int line_number)
 {
 	int i;
 
-
 	builtin_t array_of_builtins[] = {
 		{"exit", handle_exit},
 		{"env", handle_env},

--- a/check_builtins.c
+++ b/check_builtins.c
@@ -4,10 +4,13 @@
  * check_builtins - checks if cmd passed by the user is a builtins functions
  * and roots to the associated function
  * @args: pointer to array of string - args passed to our shell
+ * @prog: string - name of our program
+ * @line_number: number of the actual line
+ *
  * Return: int - (0) if success through the pointed function -
  * (-1) if don't match
  */
-int check_builtins(char **args)
+int check_builtins(char **args, char *prog, int line_number)
 {
 	int i;
 
@@ -22,7 +25,7 @@ int check_builtins(char **args)
 	while (array_of_builtins[i].name != NULL && array_of_builtins[i].f != NULL)
 	{
 		if (strcmp(array_of_builtins[i].name, args[0]) == 0)
-			return (array_of_builtins[i].f(args));
+			return (array_of_builtins[i].f(args, prog, line_number));
 		i++;
 	}
 

--- a/handle_env.c
+++ b/handle_env.c
@@ -3,12 +3,16 @@
 /**
  * handle_env - display all environment variables when `env` is called
  * @args: pointer of array of string - use to handle args for exit cmd
+ * @prog: string - name of our program (not used here)
+ * @line_number: - number of the actual line (not used here)
  * Return: int - (0) on success
  */
 
-int handle_env(char **args)
+int handle_env(char **args, char *prog, int line_number)
 {
 	int i;
+	(void)prog;
+	(void)line_number;
 
 	i = 0;
 	(void)args;

--- a/handle_exit.c
+++ b/handle_exit.c
@@ -3,12 +3,15 @@
 /**
  * is_numeric - checks if a char is a digit
  * @str: pointer to string - string to check
+ * @prog: string - name of our prog (not used here)
+ *
  * Return: (1) if string contains only digit - (0) if not
  */
 
-int is_numeric(char *str)
+int is_numeric(char *str, char *prog)
 {
 	int i;
+	(void)prog;
 
 	i = 0;
 
@@ -23,21 +26,23 @@ int is_numeric(char *str)
 /**
  * handle_exit - exit function to quit prog
  * @args: pointer of array of string - use to handle args for exit cmd
+ * @prog: string - name of our program
+ * @line_number: int - number of the actual ligne
  * Return: int
  */
 
-int handle_exit(char **args)
+int handle_exit(char **args, char *prog, int line_number)
 {
 	int exit_code;
 
 	if (!args[1])
 	exit(0);
 
-	if (is_numeric(args[1]) == 0)
+	if (is_numeric(args[1], prog) == 0)
 	{
-		/** TODO: Need to handle argv[0] to retrieve the program name */
-		fprintf(stderr, "%s: exit: %s: numeric argument required\n",
-			args[0], args[1]);
+
+		fprintf(stderr, "%s: %d: exit: Illegal number: %s\n",
+			prog, line_number, args[1]);
 		return (2);
 	}
 

--- a/handle_exit.c
+++ b/handle_exit.c
@@ -40,7 +40,6 @@ int handle_exit(char **args, char *prog, int line_number)
 
 	if (is_numeric(args[1], prog) == 0)
 	{
-
 		fprintf(stderr, "%s: %d: exit: Illegal number: %s\n",
 			prog, line_number, args[1]);
 		return (2);

--- a/main.c
+++ b/main.c
@@ -2,14 +2,18 @@
 
 /**
  * main - entry point
+ * @argc: void - number of arguments
+ * @argv: array of strings - arguments of the function
  * Return: 0 if success
  */
 
-int main(void)
+int main(int argc, char **argv)
 {
 	char **args, *line = NULL;
 	size_t n = 0;
 	ssize_t user_input;
+	int line_number;
+	(void)argc;
 
 	while (1)
 	{
@@ -19,10 +23,13 @@ int main(void)
 		user_input = getline(&line, &n, stdin);
 		if (user_input == -1)
 			break;
+
+		line_number++;
+
 		args = parsing_user_input(line);
 
 		if (args != NULL && args[0] != NULL)
-			process_cmd(args);
+			process_cmd(args, argv[0], line_number);
 
 		free(args);
 	}
@@ -33,9 +40,11 @@ int main(void)
 /**
  * process_cmd - Processes the command and arguments
  * @args: array of strings - containing the command and arguments
+ * @prog: name of our programm
+ * @line_number: nb of the actual line
  */
 
-void process_cmd(char **args)
+void process_cmd(char **args, char *prog, int line_number)
 {
 	char *path;
 
@@ -53,7 +62,7 @@ void process_cmd(char **args)
 			free(path);
 		}
 		else
-			printf("Command doesn't exist\n");
+			fprintf(stderr, "%s: %d: %s: not found\n", prog, line_number, args[0]);
 	}
 	else
 		execute_cmd_line(args);

--- a/main.c
+++ b/main.c
@@ -48,7 +48,7 @@ void process_cmd(char **args, char *prog, int line_number)
 {
 	char *path;
 
-	if (check_builtins(args) != -1)
+	if (check_builtins(args, prog, line_number) != -1)
 		return;
 
 	if (check_if_command_exists(args[0]) == 1)

--- a/main.h
+++ b/main.h
@@ -36,7 +36,7 @@ int handle_env(char **args);
 int check_builtins(char **args);
 int _atoi(char *s);
 char *get_cmd_path(char *arg);
-void process_cmd(char **args);
+void process_cmd(char **args, char *prog, int line_number);
 char *_getenv(const char *target);
 
 #endif

--- a/main.h
+++ b/main.h
@@ -22,7 +22,7 @@
 typedef struct builtin_s
 {
 	char *name;
-	int (*f)(char **args);
+	int (*f)(char **args, char *prog, int line_number);
 } builtin_t;
 
 extern char **environ;
@@ -31,9 +31,9 @@ extern char **environ;
 char **parsing_user_input(char *line);
 int check_if_command_exists(char *arg);
 int execute_cmd_line(char **args);
-int handle_exit(char **args);
-int handle_env(char **args);
-int check_builtins(char **args);
+int handle_exit(char **args, char *prog, int line_number);
+int handle_env(char **args, char *prog, int line_number);
+int check_builtins(char **args, char *prog, int line_number);
 int _atoi(char *s);
 char *get_cmd_path(char *arg);
 void process_cmd(char **args, char *prog, int line_number);


### PR DESCRIPTION
# Handling Errors

```c
julien@ubuntu:/# echo "qwerty" | /bin/sh
/bin/sh: 1: qwerty: not found
```

In order to display an error that mimic the `sh` one when user enter a command that doesn't exist, i changed the signature of the `main` function to give the name of the program as argument to the `process_cmd` function.

From
```c
int main(void);
```
to
```c
int main(int argc, char **argv);
```

I set (void) to argc, we won't use it in this function.

We need to know the number of the actual line (that's the `1`in the first block of command above).
An  `int line_number;` has been declared at the beginning, and it's incremented during the loop.

We need to give this int and the name of our program (the `argv[0]`) to our process_cmd function : 
```c
process_cmd(args, argv[0], line_number);
```

Now, if the command doesn't exist, we can display a correct error message respecting the requirements : 

```c 
fprintf(stderr, "%s: %d: %s: not found\n", prog, line_number, args[0]);
```
