### PR TITLE
Feat/parsin withou strtok

### DIFF
--- a/get_cmd_path.c
+++ b/get_cmd_path.c
@@ -1,6 +1,22 @@
 #include "main.h"
 
 /**
+ * add_arg_to_path - add a / and arg at the end of a path
+ * @arg: char - first arg read by getline
+ * @full_path: string - space allocated for full path
+ * @dir: string - directory to check
+ * Return: nothing
+ */
+
+
+void add_arg_to_path(char *full_path, char *dir, char *arg)
+{
+		strcpy(full_path, dir);
+		strcat(full_path, "/");
+		strcat(full_path, arg);
+}
+
+/**
  * get_cmd_path - find the cmd in the PATH
  * @arg: char - first arg read by getline
  * Return: return the full_path if found - else return NULL
@@ -8,44 +24,46 @@
 
 char *get_cmd_path(char *arg)
 {
-
-	char *env;
-	char *env_copy;
-	char *dir;
-	char *full_path;
-	struct stat st;
-
+	char *env, *env_copy, *dir, *full_path;
+	char *start, *end;
 
 	env = _getenv("PATH");
 	env_copy = strdup(env);
-	dir = strtok(env_copy, ":");
 
-	while (dir != NULL)
+	if (!env_copy)
+		return (NULL);
+
+	start = env_copy;
+	while (start != NULL)
 	{
+		end = strchr(start, ':');
+		if (end != NULL)
+			*end = '\0';
+		if (*start == '\0') /* :: case*/
+			dir = ".";
+		else
+			dir = start;
 
 		full_path = malloc(strlen(dir) + strlen(arg) + 2);
-		if (full_path == NULL)
+
+		if (full_path)
 		{
-			free(env_copy);
-			return (NULL);
-		}
-		if (full_path != NULL)
-		{
-			strcpy(full_path, dir);
-			strcat(full_path, "/");
-			strcat(full_path, arg);
-		}
-		if (stat(full_path, &st) == 0)
+			add_arg_to_path(full_path, dir, arg);
+
+		if (access(full_path, X_OK) == 0) /*use of access instead of stat*/
 		{
 			free(env_copy);
 			return (full_path);
 		}
-		else
-			{
-				free(full_path);
-				dir = strtok(NULL, ":");
-			}
+
+		free(full_path);
+		}
+		if (end == NULL)
+			break;
+		start = end + 1;
 	}
 	free(env_copy);
 	return (NULL);
 }
+
+

--- a/get_cmd_path.c
+++ b/get_cmd_path.c
@@ -8,7 +8,6 @@
  * Return: nothing
  */
 
-
 void add_arg_to_path(char *full_path, char *dir, char *arg)
 {
 		strcpy(full_path, dir);
@@ -65,5 +64,3 @@ char *get_cmd_path(char *arg)
 	free(env_copy);
 	return (NULL);
 }
-
-

--- a/get_cmd_path.c
+++ b/get_cmd_path.c
@@ -49,13 +49,13 @@ char *get_cmd_path(char *arg)
 		{
 			add_arg_to_path(full_path, dir, arg);
 
-		if (access(full_path, X_OK) == 0) /*use of access instead of stat*/
-		{
-			free(env_copy);
-			return (full_path);
-		}
+			if (access(full_path, X_OK) == 0) /*use of access instead of stat*/
+			{
+				free(env_copy);
+				return (full_path);
+			}
 
-		free(full_path);
+			free(full_path);
 		}
 		if (end == NULL)
 			break;

--- a/parsing_user_input.c
+++ b/parsing_user_input.c
@@ -9,41 +9,41 @@
 
 char **parsing_user_input(char *line)
 {
-	int size_of_token = 80;
-	int i = 0, len = 0;
-	char *token;
+	int i = 0, len = 0, size_of_token = 80;
+	char *ptr;
 	char **tokens;
 
 	tokens = malloc(sizeof(char *) * size_of_token);
-
 	if (tokens == NULL)
 	{
 		fprintf(stderr, "Allocation failed");
 		exit(EXIT_FAILURE);
 	}
-
 	len = strlen(line);
 	if (len > 0 && line[len - 1] == '\n')
 		line[len - 1] = '\0';
 
-	token = strtok(line, " ");
-
-	if (token == NULL)
+	ptr = line;
+	while (*ptr != '\0')
 	{
-		tokens[0] = NULL;
-		return (tokens);
-	}
+		while (*ptr == ' ' || *ptr == '\t')
+			ptr++;
+		if (*ptr == '\0')
+			break;
 
-	while (token != NULL)
-	{
-		tokens[i] = token;
+		tokens[i] = ptr;
 		i++;
-		token = strtok(NULL, " ");
-
 		if (i >= size_of_token) /*if the buffer isn't big enough, realloc*/
 		{
 			size_of_token += 80;
 			tokens = realloc(tokens, size_of_token * sizeof(char *));
+		}
+		while (*ptr != ' ' && *ptr != '\t' && *ptr != '\0')
+			ptr++;
+		if (*ptr != '\0')
+		{
+			*ptr = '\0';
+			ptr++;
 		}
 	}
 	tokens[i] = NULL;


### PR DESCRIPTION
# Parsing without strtok

feat: In order to respect the requirements of an advanced task, i modified the parsing code, not using the strtok function.

## get_cmd_path.c 

Instead,in the get_cmd_path function,  i used the strchr function which returns a pointer to a separator in a string.
```c
end = strchr(start, ':');
```
When the separator is found, it become a `\0` and it's stocked in a variable that will be used later.

Then, we allocated a memory in the heap using malloc

```c
full_path = malloc(strlen(dir) + strlen(arg) + 2);
```
_Length of our token + length of our command to check + 2 (the / and the \0)_

In order to add the dir, the arg, the / and the \0, i created another function which is called in the get_cmd_path function : 

```c
/**
 * add_arg_to_path - add a / and arg at the end of a path
 * @arg: char - first arg read by getline
 * @full_path: string - space allocated for full path
 * @dir: string - directory to check
 * Return: nothing
 */

void add_arg_to_path(char *full_path, char *dir, char *arg)
{
		strcpy(full_path, dir);
		strcat(full_path, "/");
		strcat(full_path, arg);
}
```

After that, i changed the testing function :
-instead of using `stat()`, which checks if the file exists, i used `access()`, which checks whether the calling process can access the file.
-it returns 0 if we can execute the file.
-if we can execute the file, we return the full path

```c
if (access(full_path, X_OK) == 0) /*use of access instead of stat*/
		{
			free(env_copy);
			return (full_path);
		}
```

## parsing_user_input.c

In this file, i used another method
