### PR TITLE
hotfix: Reversed, use of strtok in get_cmd_path.c and parsing_user_input.c

### DIFF
--- a/get_cmd_path.c
+++ b/get_cmd_path.c
@@ -1,21 +1,6 @@
 #include "main.h"
 
 /**
- * add_arg_to_path - add a / and arg at the end of a path
- * @arg: char - first arg read by getline
- * @full_path: string - space allocated for full path
- * @dir: string - directory to check
- * Return: nothing
- */
-
-void add_arg_to_path(char *full_path, char *dir, char *arg)
-{
-		strcpy(full_path, dir);
-		strcat(full_path, "/");
-		strcat(full_path, arg);
-}
-
-/**
  * get_cmd_path - find the cmd in the PATH
  * @arg: char - first arg read by getline
  * Return: return the full_path if found - else return NULL
@@ -23,39 +8,43 @@ void add_arg_to_path(char *full_path, char *dir, char *arg)
 
 char *get_cmd_path(char *arg)
 {
-	char *env, *env_copy = NULL, *dir, *full_path;
-	char *start, *end;
+
+	char *env;
+	char *env_copy;
+	char *dir;
+	char *full_path;
+	struct stat st;
+
 
 	env = _getenv("PATH");
-	env_copy = _strdup(env);
-	start = env_copy;
-	while (start != NULL)
+	env_copy = strdup(env);
+	dir = strtok(env_copy, ":");
+
+	while (dir != NULL)
 	{
-		end = strchr(start, ':');
-		if (end != NULL)
-			*end = '\0';
-		if (*start == '\0') /* :: case*/
-			dir = ".";
-		else
-			dir = start;
 
 		full_path = malloc(strlen(dir) + strlen(arg) + 2);
-
-		if (full_path)
+		if (full_path == NULL)
 		{
-			add_arg_to_path(full_path, dir, arg);
-
-			if (access(full_path, X_OK) == 0) /*use of access instead of stat*/
-			{
-				free(env_copy);
-				return (full_path);
-			}
-
-			free(full_path);
+			free(env_copy);
+			return (NULL);
 		}
-		if (end == NULL)
-			break;
-		start = end + 1;
+		if (full_path != NULL)
+		{
+			strcpy(full_path, dir);
+			strcat(full_path, "/");
+			strcat(full_path, arg);
+		}
+		if (access(full_path, X_OK) == 0) /*use of access instead of stat*/
+		{
+			free(env_copy);
+			return (full_path);
+		}
+		else
+			{
+				free(full_path);
+				dir = strtok(NULL, ":");
+			}
 	}
 	free(env_copy);
 	return (NULL);

--- a/parsing_user_input.c
+++ b/parsing_user_input.c
@@ -3,48 +3,48 @@
 /**
  * parsing_user_input - split an input into tokens
  * @line: string - string written by the user
+ *
  * Return: array of strings - array of every arguments
  */
 
 char **parsing_user_input(char *line)
 {
-	int i = 0, len = 0, size_of_token = 80;
-	char *ptr, *end;
-	char **tokens, **tmp;
+	int size_of_token = 80;
+	int i = 0, len = 0;
+	char *token;
+	char **tokens;
 
 	tokens = malloc(sizeof(char *) * size_of_token);
+
+	if (tokens == NULL)
+	{
+		fprintf(stderr, "Allocation failed");
+		exit(EXIT_FAILURE);
+	}
+
 	len = strlen(line);
 	if (len > 0 && line[len - 1] == '\n')
 		line[len - 1] = '\0';
 
-	if (tokens == NULL)
-		exit(EXIT_FAILURE);
-	ptr = line;
-	while (*ptr != '\0')
+	token = strtok(line, " ");
+
+	if (token == NULL)
 	{
-		while (*ptr == ' ' || *ptr == '\t')
-			ptr++; /*ignores extra spaces*/
-		if (*ptr == '\0') /*end of line*/
-			break;
+		tokens[0] = NULL;
+		return (tokens);
+	}
+
+	while (token != NULL)
+	{
+		tokens[i] = token;
+		i++;
+		token = strtok(NULL, " ");
+
 		if (i >= size_of_token) /*if the buffer isn't big enough, realloc*/
 		{
 			size_of_token += 80;
-			tmp = realloc(tokens, size_of_token * sizeof(char *));
-			if (tmp == NULL)
-				exit(EXIT_FAILURE);
-			tokens = tmp;
+			tokens = realloc(tokens, size_of_token * sizeof(char *));
 		}
-		tokens[i] = ptr;
-		i++;
-
-		end = strpbrk(ptr, " \t"); /*looks for separator after a token*/
-		if (end) /*if separator found*/
-		{
-			*end = '\0';
-			ptr = end + 1;
-		}
-		else
-			break;
 	}
 	tokens[i] = NULL;
 	return (tokens);


### PR DESCRIPTION
In order to respect the requirements, we couldn't use the strpbrk and strchr functions. That's why we use strtok again.

We just changed the function stat() and use access instead 

```c
if (access(full_path, X_OK) == 0) /*use of access instead of stat*/
		{
			free(env_copy);
			return (full_path);
		}

```