### PR TITLE
fix: refacto handle exit to return a signal instead of using exit fun…

### DIFF
--- a/handle_exit.c
+++ b/handle_exit.c
@@ -33,10 +33,10 @@ int is_numeric(char *str, char *prog)
 
 int handle_exit(char **args, char *prog, int line_number)
 {
-	int exit_code;
-
 	if (!args[1])
-	exit(0);
+	{
+		return (-2);
+	}
 
 	if (is_numeric(args[1], prog) == 0)
 	{
@@ -45,9 +45,5 @@ int handle_exit(char **args, char *prog, int line_number)
 		return (2);
 	}
 
-	exit_code = _atoi(args[1]);
-
-	exit(exit_code);
-
-	return (0);
+	return (-2);
 }

--- a/main.c
+++ b/main.c
@@ -10,6 +10,7 @@
 int main(int argc, char **argv)
 {
 	char **args, *line = NULL;
+	int cmd_return, code;
 	size_t n = 0;
 	ssize_t user_input;
 	int line_number = 0;
@@ -29,7 +30,17 @@ int main(int argc, char **argv)
 		args = parsing_user_input(line);
 
 		if (args != NULL && args[0] != NULL)
-			process_cmd(args, argv[0], line_number);
+		{
+			cmd_return = process_cmd(args, argv[0], line_number);
+			if (cmd_return == -2)
+			{
+				code = args[1] ? _atoi(args[1]) : 0;
+				free(args);
+				free(line);
+				exit(code);
+			}
+		}
+
 
 		free(args);
 	}
@@ -44,12 +55,14 @@ int main(int argc, char **argv)
  * @line_number: nb of the actual line
  */
 
-void process_cmd(char **args, char *prog, int line_number)
+int process_cmd(char **args, char *prog, int line_number)
 {
 	char *path;
+	int builtins_return;
 
-	if (check_builtins(args, prog, line_number) != -1)
-		return;
+	builtins_return = check_builtins(args, prog, line_number);
+	if (builtins_return != -1)
+		return (builtins_return);
 
 	if (check_if_command_exists(args[0]) == 1)
 	{
@@ -66,4 +79,6 @@ void process_cmd(char **args, char *prog, int line_number)
 	}
 	else
 		execute_cmd_line(args);
+
+	return (0);
 }

--- a/main.h
+++ b/main.h
@@ -25,6 +25,7 @@ typedef struct builtin_s
 	int (*f)(char **args, char *prog, int line_number);
 } builtin_t;
 
+/* Global variables */
 extern char **environ;
 
 /*prototypes*/
@@ -36,7 +37,7 @@ int handle_env(char **args, char *prog, int line_number);
 int check_builtins(char **args, char *prog, int line_number);
 int _atoi(char *s);
 char *get_cmd_path(char *arg);
-void process_cmd(char **args, char *prog, int line_number);
+int process_cmd(char **args, char *prog, int line_number);
 char *_getenv(const char *target);
 char *_strdup(char *str);
 


### PR DESCRIPTION
In order to match with holberton checker for the handle_exit task behavior we need to refacto the function and return value.

I return an integer to signal that the user input is a builtin function and it's correspond to `exit`.

I return `-2` if the user want to exit the simple_shell and 2 if it's an illegal value for `exit`.

This is the value of our executable shell:
```bash
holbertonschool-simple_shell fix/refacto_handle_exit_function_avoid_memory_leaks  ❯ valgrind --leak-check=full ./a.out 
==131187== Memcheck, a memory error detector
==131187== Copyright (C) 2002-2024, and GNU GPL'd, by Julian Seward et al.
==131187== Using Valgrind-3.25.1 and LibVEX; rerun with -h for copyright info
==131187== Command: ./a.out
==131187== 
<3 ls -l
total 84
-rwxr-xr-x 1 guigui guigui 18104 Apr 23 15:17 a.out
drwxr-xr-x 1 guigui guigui    52 Apr 23 12:54 assets
-rw-r--r-- 1 guigui guigui   446 Apr 22 19:04 _atoi.c
-rw-r--r-- 1 guigui guigui   219 Apr 23 12:54 AUTHORS
-rw-r--r-- 1 guigui guigui   785 Apr 22 19:04 check_builtins.c
-rw-r--r-- 1 guigui guigui   323 Apr 22 19:04 cmd_checker.c
-rw-r--r-- 1 guigui guigui   602 Apr 22 19:04 execute_cmd_line.c
-rw-r--r-- 1 guigui guigui   834 Apr 23 14:19 get_cmd_path.c
-rw-r--r-- 1 guigui guigui   599 Apr 22 19:04 _getenv.c
-rw-r--r-- 1 guigui guigui   526 Apr 22 19:04 handle_env.c
-rw-r--r-- 1 guigui guigui   891 Apr 23 15:13 handle_exit.c
-rw-r--r-- 1 guigui guigui  1229 Apr 22 19:04 hsh.1
-rw-r--r-- 1 guigui guigui  1504 Apr 23 15:17 main.c
-rw-r--r-- 1 guigui guigui  1027 Apr 23 15:17 main.h
-rw-r--r-- 1 guigui guigui   910 Apr 23 13:55 parsing_user_input.c
-rw-r--r-- 1 guigui guigui  4404 Apr 23 12:54 README.md
-rw-r--r-- 1 guigui guigui   504 Apr 23 14:19 _strdup.c
<3 exit
==131187== 
==131187== HEAP SUMMARY:
==131187==     in use at exit: 0 bytes in 0 blocks
==131187==   total heap usage: 15 allocs, 15 frees, 4,313 bytes allocated
==131187== 
==131187== All heap blocks were freed -- no leaks are possible
==131187== 
==131187== For lists of detected and suppressed errors, rerun with: -s
==131187== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

holbertonschool-simple_shell fix/refacto_handle_exit_function_avoid_memory_leaks  ❯ echo $?
0

holbertonschool-simple_shell fix/refacto_handle_exit_function_avoid_memory_leaks  ❯ valgrind --leak-check=full ./a.out 
==131397== Memcheck, a memory error detector
==131397== Copyright (C) 2002-2024, and GNU GPL'd, by Julian Seward et al.
==131397== Using Valgrind-3.25.1 and LibVEX; rerun with -h for copyright info
==131397== Command: ./a.out
==131397== 
<3 ls -l
total 84
-rwxr-xr-x 1 guigui guigui 18104 Apr 23 15:17 a.out
drwxr-xr-x 1 guigui guigui    52 Apr 23 12:54 assets
-rw-r--r-- 1 guigui guigui   446 Apr 22 19:04 _atoi.c
-rw-r--r-- 1 guigui guigui   219 Apr 23 12:54 AUTHORS
-rw-r--r-- 1 guigui guigui   785 Apr 22 19:04 check_builtins.c
-rw-r--r-- 1 guigui guigui   323 Apr 22 19:04 cmd_checker.c
-rw-r--r-- 1 guigui guigui   602 Apr 22 19:04 execute_cmd_line.c
-rw-r--r-- 1 guigui guigui   834 Apr 23 14:19 get_cmd_path.c
-rw-r--r-- 1 guigui guigui   599 Apr 22 19:04 _getenv.c
-rw-r--r-- 1 guigui guigui   526 Apr 22 19:04 handle_env.c
-rw-r--r-- 1 guigui guigui   891 Apr 23 15:13 handle_exit.c
-rw-r--r-- 1 guigui guigui  1229 Apr 22 19:04 hsh.1
-rw-r--r-- 1 guigui guigui  1504 Apr 23 15:17 main.c
-rw-r--r-- 1 guigui guigui  1027 Apr 23 15:17 main.h
-rw-r--r-- 1 guigui guigui   910 Apr 23 13:55 parsing_user_input.c
-rw-r--r-- 1 guigui guigui  4404 Apr 23 12:54 README.md
-rw-r--r-- 1 guigui guigui   504 Apr 23 14:19 _strdup.c
<3 exit 98
==131397== 
==131397== HEAP SUMMARY:
==131397==     in use at exit: 0 bytes in 0 blocks
==131397==   total heap usage: 15 allocs, 15 frees, 4,313 bytes allocated
==131397== 
==131397== All heap blocks were freed -- no leaks are possible
==131397== 
==131397== For lists of detected and suppressed errors, rerun with: -s
==131397== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

holbertonschool-simple_shell fix/refacto_handle_exit_function_avoid_memory_leaks  ✗ echo $?
98
```

Betty code style passed:
```bash
========== _atoi.c ==========
_atoi

========== check_builtins.c ==========
check_builtins

========== cmd_checker.c ==========
check_if_command_exists

========== execute_cmd_line.c ==========
execute_cmd_line

========== get_cmd_path.c ==========
get_cmd_path

========== _getenv.c ==========
_getenv

========== handle_env.c ==========
handle_env

========== handle_exit.c ==========
is_numeric
handle_exit

========== main.c ==========
main
main.c:58: warning: No description found for return value of 'process_cmd'
process_cmd

========== parsing_user_input.c ==========
parsing_user_input

========== _strdup.c ==========
_strdup

========== main.h ==========
struct builtin_s
```